### PR TITLE
fix password options

### DIFF
--- a/script.js
+++ b/script.js
@@ -89,10 +89,10 @@ var upperCasedCharacters = [
 ];
 
 const passwordLength = prompt("Between 10 characters and 64 characters, what length would you like your password to be?");
-const specialCharsPrompt = prompt("Would you like to use Special Characters in your password?");
-const numericCharsPrompt = prompt("Would you like to use Numeric Characters in your password?");
-const lowerCasedCharsPrompt = prompt("Would you like to use Lower Cased Characters in your password?");
-const upperCasedCharsPrompt = prompt("Would you like to use  Upper Cased Characters in your password?"); 
+const specialCharsPrompt = confirm("Would you like to use Special Characters in your password?");
+const numericCharsPrompt = confirm("Would you like to use Numeric Characters in your password?");
+const lowerCasedCharsPrompt = confirm("Would you like to use Lower Cased Characters in your password?");
+const upperCasedCharsPrompt = confirm("Would you like to use  Upper Cased Characters in your password?"); 
 
 // Function to prompt user for password options
 function getPasswordOptions() {
@@ -110,32 +110,24 @@ function getPasswordOptions() {
     confirm("Thank you for choosing a length for your password.");
   }
   if (specialCharsPrompt === false) {
-    alert("You have chosen to not include a Special Character in your password.");
-  } else if(specialCharsPrompt !== specialCharacters) {
-    alert("Please enter Special Characters from this selection: " + specialCharacters + ".");
-  }  {
-    confirm("Thank you for choosing your Special Character(s)");
+    confirm("You have chosen to not include a Special Character in your password.");
+  } else {
+    confirm("You have chosen to use Special Character(s)");
   }
   if (numericCharsPrompt === false) {
     alert("You have chosen to not include a Numeric Character in your password.");
-  } else if(numericCharsPrompt !== numericCharacters) {
-    alert("Please enter Numeric Characters from this selection: " + numericCharacters + ".");
   } else {
-    confirm("Thank you for choosing your Numeric Character(s)");
+    confirm("You have chosen to use Numeric Character(s)");
   }
   if (lowerCasedCharsPrompt === false) {
     alert("You have chosen to not include a Lower Cased Character in your password.");
-  } else if(lowerCasedCharsPrompt !== lowerCasedCharacters) {
-    alert("Please enter Lower Cased Characters from this selection: " + lowerCasedCharacters + ".");
   } else {
-    confirm("Thank you for choosing your Lower Cased Character(s)");
+    confirm("You have chosen to use Lower Cased Character(s)");
   }  
   if (upperCasedCharsPrompt === false) {
     alert("You have chosen to not include an Upper Cased Character in your password.");
-  } else if(upperCasedCharsPrompt !== upperCasedCharacters) {
-    alert("Please enter Upper Cased Characters from this selection: " + upperCasedCharacters + ".");
   } else {
-    confirm("Thank you for choosing your Upper Cased Character(s)");
+    confirm("You have chosen to use Upper Cased Character(s)");
   }
   return;
 }


### PR DESCRIPTION
This PR uses confirm instead of prompt for the password option characters so that it is easier to create the password by using Boolean.